### PR TITLE
Add add_name route

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,7 @@ authors = [ "Ross Schulman <ross@rbs.io>" ]
 version = "0.4"
 default-features = false
 features = ["yaml"]
+
+[dependencies]
+rocket = "0.2.3"
+rocket-codegen = "0.2.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,4 +4,7 @@ name = "westwork"
 version = "0.0.1"
 authors = [ "Ross Schulman <ross@rbs.io>" ]
 
-[dependencies]
+[dependencies.config]
+version = "0.4"
+default-features = false
+features = ["yaml"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,12 @@ features = ["yaml"]
 
 [dependencies]
 rocket = "0.2.3"
-rocket-codegen = "0.2.3"
+rocket_codegen = "0.2.3"
+serde = "0.9"
+serde_json = "0.9"
+serde_derive = "0.9"
+
+[dependencies.rocket_contrib]
+version = "0.2.3"
+default-features = false
+features = ["json"]

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -1,3 +1,9 @@
+use rocket::State;
+use config::Config;
+use rocket_contrib::{JSON, Value};
+use std::collections::HashMap;
+use WestworkConf;
+
 // TODO: How to handle names that don't follow the First Last template
 #[derive(Deserialize)]
 struct Name {
@@ -5,11 +11,12 @@ struct Name {
     last: String
 }
 
-#[post("/add_name", format = "application/json" data = "<name>")]
-fn add_name(name: JSON<Name>, conf: State<Config>) -> JSON<Value> {
+#[post("/add_name", format = "application/json", data = "<name>")]
+fn add_name(name: JSON<Name>, conf: State<WestworkConf>) -> JSON<Value> {
     // Receive the new user's name and insert into the state
-    conf.set(&"first_name", name.first);
-    conf.set(&"last_name", name.last);
+    let mut this_conf = conf.lock().expect("Failed to lock conf");
+    this_conf.set(&"first_name", name.0.first);
+    this_conf.set(&"last_name", name.0.last);
     let mut resp = HashMap::new();
     resp.insert("success", "true");
     resp.insert("next_html", "<span id='boot-ques'>What would you like your username to be?</span>\

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -1,0 +1,22 @@
+// TODO: How to handle names that don't follow the First Last template
+#[derive(Deserialize)]
+struct Name {
+    first: String,
+    last: String
+}
+
+#[post("/add_name", format = "application/json" data = "<name>")]
+fn add_name(name: JSON<Name>, conf: State<Config>) -> JSON<Value> {
+    // Receive the new user's name and insert into the state
+    conf.set(&"first_name", name.first);
+    conf.set(&"last_name", name.last);
+    let mut resp = HashMap::new();
+    resp.insert("success", "true");
+    resp.insert("next_html", "<span id='boot-ques'>What would you like your username to be?</span>\
+                              <div id='boot-form'>\
+                              <form action='add_username'>\
+                                  <input type='text' placeholder='Username'>\
+                              </form>\
+                              </div>");
+    JSON(json!(resp))
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,9 @@
+#![feature(plugin)]
+#![plugin(rocket_codegen)]
+
 extern crate config;
+extern crate rocket;
+
 use config::{Config, File, FileFormat};
 
 const settings_path: String = "/data/conf/westwork/settings.yaml"

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,8 @@ extern crate rocket;
 
 use config::{Config, File, FileFormat};
 
+mod bootstrap;
+
 const settings_path: String = "/data/conf/westwork/settings.yaml"
 
 fn main () {
@@ -18,6 +20,6 @@ fn main () {
     }
 
 
-    
+    rocket::ignite().mount("/", routes!([bootstrap::add_name])).manage(conf).launch();
 
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 extern crate config;
 use config::{Config, File, FileFormat};
 
-const settings_path = "/data/conf/westwork/settings.yaml"
+const settings_path: String = "/data/conf/westwork/settings.yaml"
 
 fn main () {
     let mut conf = config::Config::new();
@@ -12,7 +12,7 @@ fn main () {
         conf.set(&"configured", false);
     }
 
-    
+
     
 
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,23 +3,35 @@
 
 extern crate config;
 extern crate rocket;
+extern crate serde_json;
+#[macro_use] extern crate rocket_contrib;
+#[macro_use] extern crate serde_derive;
 
 use config::{Config, File, FileFormat};
+use rocket_contrib::{JSON, Value};
+use rocket::State;
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::{Arc, Mutex};
 
 mod bootstrap;
 
-const settings_path: String = "/data/conf/westwork/settings.yaml"
+const settings_path: &str = "/data/conf/westwork/settings.yaml";
+
+type WestworkConf = Arc<Mutex<Config>>;
 
 fn main () {
-    let mut conf = config::Config::new();
-
-    if (Path::new(settings_path).exists()) {
-        conf.merge(File::new(settings_path), FileFormat::Yaml).unwrap();
+    let conf = Arc::new(Mutex::new(config::Config::new()));
+    let cloned_conf = conf.clone();
+    let mut this_conf = cloned_conf.lock().expect("Failed to lock config.");
+    if Path::new(settings_path).exists() {
+        this_conf.merge(File::new(settings_path, FileFormat::Yaml)).unwrap();
     } else {
-        conf.set(&"configured", false);
+        this_conf.set(&"configured", false);
     }
+    drop(this_conf);
 
 
-    rocket::ignite().mount("/", routes!([bootstrap::add_name])).manage(conf).launch();
+    rocket::ignite().mount("/", routes![bootstrap::add_name]).manage(conf).launch();
 
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,18 @@
+extern crate config;
+use config::{Config, File, FileFormat};
 
+const settings_path = "/data/conf/westwork/settings.yaml"
 
 fn main () {
+    let mut conf = config::Config::new();
+
+    if (Path::new(settings_path).exists()) {
+        conf.merge(File::new(settings_path), FileFormat::Yaml).unwrap();
+    } else {
+        conf.set(&"configured", false);
+    }
+
+    
+    
 
 }


### PR DESCRIPTION
This PR creates the bootstrap mod, which should be used for first boot of the system and initial configuration. It also creates the add_name route for receiving the end-user's first and last name, and adds them to the config global object.